### PR TITLE
Add `rust-init` feature with `ndk-context` and update `AndroidBuilder::new` to accept `&JNIEnv`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,12 +24,13 @@ dependencies = [
 
 [[package]]
 name = "android-keyring"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "android_log-sys",
  "base64",
  "jni",
  "keyring",
+ "ndk-context",
  "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
@@ -367,6 +368,12 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,9 @@ readme = "README.md"
 crate-type = ["lib", "cdylib"]
 
 [features]
-default = []
+default = ["ndk-context"]
 compile_tests = []
 android-log = ["android_log-sys", "tracing-subscriber/env-filter"]
-rust-init = ["ndk-context"]
 
 [dependencies]
 android_log-sys = { version = "0.3.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["password", "credential", "keychain", "android", "keystore"]
 license = "MIT"
 name = "android-keyring"
 repository = "https://github.com/Andrepuel/android-keyring.git"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 readme = "README.md"
 
@@ -17,6 +17,7 @@ crate-type = ["lib", "cdylib"]
 default = []
 compile_tests = []
 android-log = ["android_log-sys", "tracing-subscriber/env-filter"]
+rust-init = ["ndk-context"]
 
 [dependencies]
 android_log-sys = { version = "0.3.2", optional = true }
@@ -26,3 +27,4 @@ keyring = "=4.0.0-rc.1"
 thiserror = "2.0.12"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", optional = true }
+ndk-context = { version = "0.1.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -4,16 +4,34 @@ Pure Rust integration of Android's `KeyStore` and Android's `SharedPreferences`
 with crate [keyring](https://crates.io/crates/keyring).
 
 The Java API is called by using JNI, so no actual Java code needs to be inserted
-in the end project. Only the initialization function as an instance of
-`android.content.Context` is needed in order to fetch a `SharedPreferences`
-instance.
+in the project.
 
 ## Experimental
 
 This project should not be deemed mature enough for production level or
 sensitive applications.
 
-# Activating Android Keyring
+# Initialization
+
+There are two options for setting Android Keyring as the default entry builder
+for `keyring-rs`.
+
+## `ndk-context` (Recommended)
+
+This option is the recommended option and works out of box for projects that do
+setup `ndk-context`, (e.g., Dioxus Mobile, Tauri Mobile and android-activity).
+
+Invoke the initialization function once on the startup of the project:
+
+```rust
+android_keyring::set_android_keyring_credential_builder().unwrap();
+```
+
+# Manual initialization through Java/Kotlin Code
+
+If the project does not support `ndk-context` (e.g. Flutter/FRB), then
+Java/Kotlin code must be inserted into the project so that the Andorid Keyring
+application has access to the JNI context and the Android's Activity context.
 
 Insert the following Kotlin code into your Android project:
 

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -26,7 +26,7 @@ pub struct AndroidBuilder {
     context: Context,
 }
 impl AndroidBuilder {
-    pub fn new(env: JNIEnv, context: Context) -> AndroidKeyringResult<Self> {
+    pub fn new(env: &JNIEnv, context: Context) -> AndroidKeyringResult<Self> {
         let java_vm = env.get_java_vm()?;
         Ok(Self { java_vm, context })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 use jni::{JNIEnv, objects::JObject};
 use shared_preferences::Context;
 
+#[cfg(feature = "rust-init")]
+use crate::credential::AndroidKeyringError;
+
 #[cfg(feature = "android-log")]
 pub mod android_log;
 pub mod cipher;
@@ -36,7 +39,7 @@ pub extern "system" fn Java_io_crates_keyring_Keyring_00024Companion_setAndroidK
         }
     };
 
-    let builder = match credential::AndroidBuilder::new(env, context) {
+    let builder = match credential::AndroidBuilder::new(&env, context) {
         Ok(builder) => builder,
         Err(e) => {
             tracing::error!(%e, "error initialized AndroidBuilder credential builder");
@@ -46,4 +49,26 @@ pub extern "system" fn Java_io_crates_keyring_Keyring_00024Companion_setAndroidK
     };
 
     keyring::set_default_credential_builder(Box::new(builder));
+}
+
+/// Initializes the android-keyring from pure Rust (no Java call needed).
+/// Requires the `rust-init` feature.
+#[cfg(feature = "rust-init")]
+pub fn set_android_keyring_credential_builder() -> Result<(), AndroidKeyringError> {
+    use crate::credential::AndroidBuilder;
+
+    let ctx = ndk_context::android_context();
+    let vm = ctx.vm().cast();
+    let activity = ctx.context();
+
+    let java_vm = unsafe { jni::JavaVM::from_raw(vm)? };
+    let env = java_vm.attach_current_thread()?;
+    let context = unsafe { JObject::from_raw(activity as jni::sys::jobject) };
+
+    let android_ctx = Context::new(&env, context)?;
+    let builder = AndroidBuilder::new(&env, android_ctx)?;
+
+    keyring::set_default_credential_builder(Box::new(builder));
+
+    Ok(())
 }


### PR DESCRIPTION
### Summary

This PR introduces a new `rust-init` feature to support initializing the Android keyring from native Rust environments (e.g., Dioxus Mobile or Tauri Mobile). It also updates the `AndroidBuilder::new` constructor to accept a `&JNIEnv` reference instead of taking ownership.

### Changes

- Added new optional dependency: `ndk-context`
- Introduced `rust-init` feature in `Cargo.toml`
- Added new function:
  ```rust
  #[cfg(feature = "rust-init")]
  pub fn set_android_keyring_credential_builder() -> Result<(), AndroidKeyringError>
